### PR TITLE
Simple code (maybe) and fix bug in checking weekday

### DIFF
--- a/test/crontab_test.exs
+++ b/test/crontab_test.exs
@@ -13,4 +13,20 @@ defmodule Tarearbol.Crontab.Test do
     assert greedy[:next] ==
              Enum.map(lazy, &[{:timestamp, &1[:next]}, {:microsecond, &1[:microsecond]}])
   end
+
+  test "step on range" do
+    {:ok, dt, _} = DateTime.from_iso8601("2019-06-10T00:00:00Z")
+    {:ok, nxt, _} = DateTime.from_iso8601("2019-06-10T00:03:00Z")
+    cron = "3-9/2 * * * *"
+    assert nxt == Tarearbol.Crontab.next(dt, cron) |> Keyword.get(:next)
+  end
+
+  test "day of week and month+day are not co-dependent" do
+    {:ok, dt, _} = DateTime.from_iso8601("2019-06-10T00:00:00Z")
+    {:ok, nxt, _} = DateTime.from_iso8601("2019-06-12T00:00:00Z")
+    {:ok, nxt2, _} = DateTime.from_iso8601("2019-06-17T00:00:00Z")
+    cron = "0 0 12 6 1"
+    assert nxt == Tarearbol.Crontab.next(%{dt | minute: 1}, cron) |> Keyword.get(:next)
+    assert nxt2 == Tarearbol.Crontab.next(%{nxt | minute: 1}, cron) |> Keyword.get(:next)
+  end
 end


### PR DESCRIPTION
Bugs fixed:
* Weekday was checked against the initial date's DOW instead of the streamed one
* Steps on ranges must begin from the initial point: `3-7/2` should be `3,5,7` and not `4,6`
* Both POSIX and BSD crontabs indicates that, when both are specified, day-of-month and day-of-week are "alternatives" (the time is matched if either of them matches). 

There is a big difference in that in POSIX the DOW matching ignores the month (`0 0 1 1 1` matches January 1st and _all_ Mondays), while in BSD it takes the month into account (`0 0 1 1 1` matches January 1st and all Mondays in January). Here the POSIX behavior is added. https://crontab.guru uses the BSD definition.

Improvements:
* Less code in the main streaming function, prepending `Stream.filter` and `Stream.drop_while` when needed, instead of returning empty substreams from the inner `Stream.transform`.
* The check for being `before` the current date is done using tuple comparison, which is more readable. It's still in a function call, it can be in a pattern match but I don't think that there is a huge performance hit (compared to the readability improvement)

Notice that numbers < atoms in term ordering, so `{1, 2, nil, nil, nil} > {1, 2, 3, 4 ,5}`, but on the other side tuples are first compared by size (thus the padding with nils).
