### PR TITLE
Feature/track business of workers, pools, better cast/call

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,7 @@
+locals_without_parens = Enum.flat_map(0..9, &[defsynch: &1, defasynch: &1])
+
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -2,22 +2,30 @@ name: Dialyzer
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+    - cron: "30 1 * * *"
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    env:
+      MIX_ENV: ci
+    name: OTP ${{matrix.pair.otp}} / Elixir ${{matrix.pair.elixir}}
     strategy:
+      fail-fast: false
       matrix:
-        otp: ["23.0"]
-        elixir: [1.11.3]
+        include:
+          - pair:
+              otp: 22.3
+              elixir: 1.10.4
+          - pair:
+              otp: 23.2.5
+              elixir: 1.11.3
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: MIX_ENV=ci mix deps.get
-      - run: MIX_ENV=ci mix deps.compile
-      - run: MIX_ENV=ci mix quality.ci
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+      - run: mix deps.get
+      - run: mix deps.compile
+      - run: mix quality.ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,22 +5,30 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    env:
+      MIX_ENV: test
+    name: OTP ${{matrix.pair.otp}} / Elixir ${{matrix.pair.elixir}}
     strategy:
+      fail-fast: false
       matrix:
-        otp: ["22.2", "23.0"]
-        elixir: [1.10.3, 1.11.3]
+        include:
+          - pair:
+              otp: 22.3
+              elixir: 1.10.1
+          - pair:
+              otp: 23.2.5
+              elixir: 1.11.3
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
       - name: Install → Compile dependencies
         run: |
           epmd -daemon
-          MIX_ENV=test mix deps.get
-          MIX_ENV=test mix deps.compile
+          mix deps.get
+          mix deps.compile
       - name: Run tests
         run: |
-          MIX_ENV=test mix test
+          mix test

--- a/lib/tarearbol/dynamic_management/dynamic_supervisor.ex
+++ b/lib/tarearbol/dynamic_management/dynamic_supervisor.ex
@@ -8,7 +8,7 @@ defmodule Tarearbol.DynamicSupervisor do
   @spec start_link(opts :: keyword()) :: Supervisor.on_start()
   def start_link(opts \\ []) do
     {manager, opts} = Keyword.pop(opts, :manager)
-    DynamicSupervisor.start_link(__MODULE__, opts, name: manager.dynamic_supervisor_module())
+    DynamicSupervisor.start_link(__MODULE__, opts, name: manager.__dynamic_supervisor_module__())
   end
 
   @impl DynamicSupervisor

--- a/lib/tarearbol/dynamic_management/dynamic_worker.ex
+++ b/lib/tarearbol/dynamic_management/dynamic_worker.ex
@@ -69,10 +69,13 @@ defmodule Tarearbol.DynamicWorker do
 
   @impl GenServer
   def handle_info(:work, %{manager: manager, id: id, payload: payload} = state) do
-    id
-    |> handle_request(manager)
-    |> manager.perform(payload)
-    |> handle_response(state)
+    state =
+      id
+      |> handle_request(manager)
+      |> manager.perform(payload)
+      |> handle_response(state)
+
+    {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/tarearbol/dynamic_management/dynamic_worker.ex
+++ b/lib/tarearbol/dynamic_management/dynamic_worker.ex
@@ -148,7 +148,13 @@ defmodule Tarearbol.DynamicWorker do
         state
 
       :multihalt ->
-        Tarearbol.InternalWorker.multidel(manager.internal_worker_module(), id)
+        Logger.warning("""
+        Returning `:multihalt` from callbacks is deprecated.
+        Use `distributed: true` parameter in call to `use Tarearbol.DynamicManager`
+          and return regular `:halt` instead.
+        """)
+
+        Tarearbol.InternalWorker.del(manager.internal_worker_module(), id)
         state
 
       {:replace, ^payload} ->

--- a/lib/tarearbol/dynamic_management/dynamic_worker.ex
+++ b/lib/tarearbol/dynamic_management/dynamic_worker.ex
@@ -172,9 +172,9 @@ defmodule Tarearbol.DynamicWorker do
         Tarearbol.InternalWorker.put(manager.internal_worker_module(), new_id, payload)
         %{state | id: new_id, payload: payload}
 
-      {{:timeout, timeout}, result} ->
+      {{:timeout, new_timeout}, result} ->
         restate.(result)
-        %{state | timeout: timeout}
+        %{state | timeout: new_timeout, payload: result, lull: lull * new_timeout / timeout}
 
       {:ok, result} ->
         restate.(result)

--- a/lib/tarearbol/dynamic_management/internal_worker.ex
+++ b/lib/tarearbol/dynamic_management/internal_worker.ex
@@ -9,7 +9,9 @@ defmodule Tarearbol.InternalWorker do
 
   def start_link(manager: manager),
     do:
-      GenServer.start_link(__MODULE__, [manager: manager], name: manager.internal_worker_module())
+      GenServer.start_link(__MODULE__, [manager: manager],
+        name: manager.__internal_worker_module__()
+      )
 
   @impl GenServer
   def init(opts), do: {:ok, opts, {:continue, :init}}
@@ -63,7 +65,7 @@ defmodule Tarearbol.InternalWorker do
   def handle_continue(:init, [manager: manager] = state) do
     Enum.each(manager.children_specs(), &do_put(manager, &1))
 
-    manager.state_module().update_state(:started)
+    manager.__state_module__().update_state(:started)
     manager.handle_state_change(:started)
     {:noreply, state}
   end
@@ -76,7 +78,7 @@ defmodule Tarearbol.InternalWorker do
 
   @impl GenServer
   def handle_cast(:restart, [manager: manager] = state) do
-    manager.state_module()
+    manager.__state_module__()
     |> Process.whereis()
     |> Process.exit(:shutdown)
 
@@ -97,16 +99,16 @@ defmodule Tarearbol.InternalWorker do
   defp do_put(manager, {id, opts}) do
     do_del(manager, id)
 
-    name = {:via, Registry, {manager.registry_module(), id}}
+    name = {:via, Registry, {manager.__registry_module__(), id}}
 
     {:ok, pid} =
       DynamicSupervisor.start_child(
-        manager.dynamic_supervisor_module(),
+        manager.__dynamic_supervisor_module__(),
         {Tarearbol.DynamicWorker,
          opts |> Map.new() |> Map.merge(%{id: id, manager: manager, name: name})}
       )
 
-    manager.state_module().put(id, %{pid: name, opts: opts})
+    manager.__state_module__().put(id, %{pid: name, opts: opts})
     pid
   end
 
@@ -116,11 +118,11 @@ defmodule Tarearbol.InternalWorker do
     |> do_get(id)
     |> case do
       %{pid: {:via, Registry, {_, ^id}}} = found ->
-        manager.state_module().del(id)
+        manager.__state_module__().del(id)
 
-        case Registry.lookup(manager.registry_module(), id) do
+        case Registry.lookup(manager.__registry_module__(), id) do
           [{pid, _}] ->
-            DynamicSupervisor.terminate_child(manager.dynamic_supervisor_module(), pid)
+            DynamicSupervisor.terminate_child(manager.__dynamic_supervisor_module__(), pid)
             found
 
           [] ->
@@ -136,5 +138,5 @@ defmodule Tarearbol.InternalWorker do
   end
 
   @spec do_get(manager :: module(), id :: DynamicManager.id()) :: map()
-  defp do_get(manager, id), do: manager.state_module().get(id, %{})
+  defp do_get(manager, id), do: manager.__state_module__().get(id, %{})
 end

--- a/lib/tarearbol/dynamic_management/internal_worker.ex
+++ b/lib/tarearbol/dynamic_management/internal_worker.ex
@@ -93,7 +93,7 @@ defmodule Tarearbol.InternalWorker do
   def handle_call({:get, id}, _from, [manager: manager] = state),
     do: {:reply, do_get(manager, id), state}
 
-  @spec do_put(manager :: module(), {id :: any(), opts :: Enum.t()}) :: pid()
+  @spec do_put(manager :: module(), {id :: DynamicManager.id(), opts :: Enum.t()}) :: pid()
   defp do_put(manager, {id, opts}) do
     do_del(manager, id)
 

--- a/lib/tarearbol/pool.ex
+++ b/lib/tarearbol/pool.ex
@@ -1,0 +1,104 @@
+defmodule Tarearbol.Pool do
+  @moduledoc """
+  The pool of workers.
+  """
+
+  alias Tarearbol.Utils
+
+  defmacro __using__(opts) do
+    pool_size = Utils.get_opt(opts, :pool_size, 5)
+    timeout = Utils.get_opt(opts, :pool_timeout, 0)
+
+    payload =
+      opts
+      |> Keyword.get(:payload, %{})
+      |> Macro.escape()
+
+    continue = Keyword.get(opts, :continue)
+
+    ast =
+      quote generated: true, location: :keep do
+        use Tarearbol.DynamicManager, continue: unquote(continue)
+
+        # @before_compile Tarearbol.Pool
+        # @on_definition Tarearbol.Pool
+
+        import Tarearbol.Pool, only: [defsynch: 2, defasynch: 2]
+
+        def children_specs do
+          for i <- 1..unquote(pool_size),
+              into: %{},
+              do: {i, payload: unquote(payload), timeout: unquote(timeout)}
+        end
+
+        defoverridable children_specs: 0
+      end
+
+    ast
+  end
+
+  @spec params(:call | :cast, {module(), keyword(), [ast]}) :: ast when ast: Macro.t()
+  defp params(:call, {fun, meta, params}),
+    do: [{:{}, meta, [fun | params]}, {:_from, [], Elixir}, {:κ, [], Elixir}]
+
+  defp params(:cast, {fun, meta, params}),
+    do: [{:{}, meta, [fun | params]}, {:κ, [], Elixir}]
+
+  # defp call_reply(opts) do
+  #   case Keyword.pop(opts, :do) do
+  #     {nil, rest} ->
+  #       rest
+  #     {{:__block__, meta, exprs}, rest} ->
+  #       [last | exprs] = Enum.reverse(exprs)
+  #       exprs = [{:reply, {:λ_result, [], Elixir}}, {:=, [], [{:λ_result, [], Elixir}, last]} | exprs]
+  #       rest ++ [{:do, {:__block__, meta, Enum.reverse(exprs)}}]
+  #     {expr, rest} ->
+  #       expr = [{:reply, {:λ_result, [], Elixir}}, {:=, [], [{:λ_result, [], Elixir}, expr]}]
+  #       rest ++ [{:do, {:__block__, [], expr}}]
+  #   end
+  # end
+
+  defmacro defsynch(definition, opts),
+    do: do_def(:call, definition, opts)
+
+  defmacro defasynch(definition, opts),
+    do: do_def(:cast, definition, opts)
+
+  @interface %{cast: :asynch_call, call: :synch_call}
+  defp do_def(synch, definition, opts) do
+    definition
+    |> case do
+      {:when, meta, [fun, guards]} ->
+        [param | _] = params = params(synch, fun)
+
+        [
+          {:def, meta, [{:when, meta, [{synch, [context: Elixir], params}, guards]}, opts]},
+          {:def, [context: Elixir, import: Kernel],
+           [fun, [do: {@interface[synch], [], [nil, param]}]]}
+        ]
+
+      {_fun, meta, _params} = fun ->
+        [param | _] = params = params(synch, fun)
+
+        [
+          {:def, meta, [{synch, [context: Elixir], params}, opts]},
+          {:def, [context: Elixir, import: Kernel],
+           [fun, [do: {@interface[synch], [], [nil, param]}]]}
+        ]
+    end
+    |> Macro.prewalk(fn
+      {:state!, meta, []} -> {:κ, meta, Elixir}
+      {:id!, meta, []} -> {:elem, [context: Elixir, import: Kernel], [{:κ, meta, Elixir}, 0]}
+      {:payload!, meta, []} -> {:elem, [context: Elixir, import: Kernel], [{:κ, meta, Elixir}, 1]}
+      other -> other
+    end)
+  end
+
+  # def __on_definition__(_env, kind, name, args, guards, body) do
+  #   # IO.inspect({kind, name, args, guards, body}, limit: :infinity)
+  # end
+
+  # def __before_compile__(env) do
+  #   # IO.inspect(env, limit: :infinity)
+  # end
+end

--- a/lib/tarearbol/pool.ex
+++ b/lib/tarearbol/pool.ex
@@ -21,8 +21,6 @@ defmodule Tarearbol.Pool do
         use Tarearbol.DynamicManager, init: unquote(init)
 
         # @before_compile Tarearbol.Pool
-        # @on_definition Tarearbol.Pool
-
         import Tarearbol.Pool, only: [defsynch: 2, defasynch: 2]
 
         def children_specs do
@@ -100,10 +98,6 @@ defmodule Tarearbol.Pool do
       other -> other
     end)
   end
-
-  # def __on_definition__(_env, kind, name, args, guards, body) do
-  #   # IO.inspect({kind, name, args, guards, body}, limit: :infinity)
-  # end
 
   # def __before_compile__(env) do
   #   # IO.inspect(env, limit: :infinity)

--- a/lib/tarearbol/scheduler.ex
+++ b/lib/tarearbol/scheduler.ex
@@ -187,7 +187,7 @@ defmodule Tarearbol.Scheduler do
     end
   end
 
-  @spec active_jobs :: %{atom() => %Tarearbol.DynamicManager.Child{}}
+  @spec active_jobs :: %{Tarearbol.DynamicManager.id() => %Tarearbol.DynamicManager.Child{}}
   def active_jobs, do: state().children
 
   @doc """

--- a/lib/tarearbol/utils.ex
+++ b/lib/tarearbol/utils.ex
@@ -98,4 +98,10 @@ defmodule Tarearbol.Utils do
   @doc false
   def random_module_name(prefix \\ "M"),
     do: Enum.join([prefix, abs(:erlang.unique_integer())], "_")
+
+  #############################################################################
+
+  @doc false
+  def get_opt(opts, name, default \\ nil),
+    do: Keyword.get(opts, name, Application.get_env(:tarearbol, name, default))
 end

--- a/mix.exs
+++ b/mix.exs
@@ -133,6 +133,7 @@ defmodule Tarearbol.Mixfile do
     ]
   end
 
+  defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(:ci), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]

--- a/mix.exs
+++ b/mix.exs
@@ -118,7 +118,8 @@ defmodule Tarearbol.Mixfile do
           Tarearbol
         ],
         "Dymanic Supervisor Sugar": [
-          Tarearbol.DynamicManager
+          Tarearbol.DynamicManager,
+          Tarearbol.Pool
         ],
         Scheduler: [
           Tarearbol.Calendar,

--- a/stuff/pages/cron_management.md
+++ b/stuff/pages/cron_management.md
@@ -20,7 +20,7 @@ Jobs description are loaded upon application start from one of the following loc
 
 Upon start, it loads jobs schedules and spawns processes for each, managed by `Tarearbol.DynamicManager`. Each job must return on of the following three outcomes.
 
-- `{:ok, any()}` to normally return the result to be stored as last job execution result in the state of `Tarearbol.DynamicSupervisor` and reschedule the job to the next event
+- `{:ok, any()}` to normally return the result to be stored as last job execution result in the state of `Manager` and reschedule the job to the next event
 - `:halt` to prevent further job executions and remove it from the list of scheduled jobs
 - `{{:reschedule, binary()}, any()}` to reschedule the job with new cron record, given as the second parameter of the first tuple.
 

--- a/test/dynamic_manager_test.exs
+++ b/test/dynamic_manager_test.exs
@@ -139,16 +139,15 @@ defmodule Tarearbol.DynamicManager.Test do
       @impl Tarearbol.DynamicManager
       def perform(i, timeout) do
         send(:erlang.binary_to_term(i), "pong")
-        {{:timeout, timeout * 2}, timeout * 2}
+        {{:timeout, timeout * 10}, timeout * 10}
       end
     end
 
     {:ok, pid5} = PingPong5.start_link()
     refute_receive "pong", 50
     assert_receive "pong", 500
-    assert_receive "pong", 500
-    refute_receive "pong", 200
-    assert_receive "pong", 500
+    refute_receive "pong", 300
+    assert_receive "pong", 1_000
     PingPong5.del(:erlang.term_to_binary(self()))
     Process.sleep(10)
     assert map_size(PingPong5.state().children) == 0

--- a/test/dynamic_manager_test.exs
+++ b/test/dynamic_manager_test.exs
@@ -149,13 +149,12 @@ defmodule Tarearbol.DynamicManager.Test do
     assert_receive "pong", 500
     refute_receive "pong", 200
     assert_receive "pong", 500
-    # Process.sleep(2_000)
     PingPong5.del(:erlang.term_to_binary(self()))
     Process.sleep(10)
     assert map_size(PingPong5.state_module().state().children) == 0
     GenServer.stop(pid5)
 
-    Enum.each([PingPong4], fn mod ->
+    Enum.each([PingPong5], fn mod ->
       :code.delete(mod)
       :code.purge(mod)
       mod = Module.concat([mod, State])

--- a/test/dynamic_manager_test.exs
+++ b/test/dynamic_manager_test.exs
@@ -77,9 +77,9 @@ defmodule Tarearbol.DynamicManager.Test do
 
     Process.sleep(200)
 
-    assert PingPong1.state_module().state().children == %{}
-    assert PingPong2.state_module().state().children == %{}
-    refute PingPong3.state_module().state().children == %{}
+    assert PingPong1.state().children == %{}
+    assert PingPong2.state().children == %{}
+    refute PingPong3.state().children == %{}
 
     GenServer.stop(pid3)
     GenServer.stop(pid2)
@@ -112,11 +112,11 @@ defmodule Tarearbol.DynamicManager.Test do
     PingPong4.put(:erlang.term_to_binary(self()), timeout: 100)
     assert_receive "pong", 200
     PingPong4.put(:erlang.term_to_binary(self()), timeout: 100)
-    assert map_size(PingPong4.state_module().state().children) == 1
+    assert map_size(PingPong4.state().children) == 1
     assert_receive "pong", 200
     PingPong4.del(:erlang.term_to_binary(self()))
     Process.sleep(10)
-    assert map_size(PingPong4.state_module().state().children) == 0
+    assert map_size(PingPong4.state().children) == 0
     GenServer.stop(pid4)
 
     Enum.each([PingPong4], fn mod ->
@@ -151,7 +151,7 @@ defmodule Tarearbol.DynamicManager.Test do
     assert_receive "pong", 500
     PingPong5.del(:erlang.term_to_binary(self()))
     Process.sleep(10)
-    assert map_size(PingPong5.state_module().state().children) == 0
+    assert map_size(PingPong5.state().children) == 0
     GenServer.stop(pid5)
 
     Enum.each([PingPong5], fn mod ->

--- a/test/pool_test.exs
+++ b/test/pool_test.exs
@@ -29,7 +29,7 @@ defmodule Tarearbol.DynamicManager.Pool.Test do
              1..5 |> Task.async_stream(&Tarearbol.Full.asynch/1) |> Enum.to_list() |> Enum.uniq()
 
     Process.sleep(700)
-    assert 20 == Enum.reduce(Tarearbol.Full.State.state().children, 0, &(&2 + elem(&1, 1).value))
+    assert [20, 2] == Enum.map(Tarearbol.Full.state().children, &elem(&1, 1).value)
 
     GenServer.stop(pid)
   end

--- a/test/pool_test.exs
+++ b/test/pool_test.exs
@@ -1,0 +1,36 @@
+defmodule Tarearbol.DynamicManager.Pool.Test do
+  @moduledoc false
+
+  use ExUnit.Case
+  doctest Tarearbol.DynamicManager
+
+  setup do
+    # with {:ok, pid} <- DynamicManager.start_link(), do: [pid: pid]
+    :ok
+  end
+
+  test "acts as expected" do
+    {:ok, pid} = Tarearbol.Full.start_link()
+
+    Process.sleep(100)
+
+    assert Tarearbol.Full.synch() == {:ok, 1}
+    assert Tarearbol.Full.synch() == {:ok, 2}
+    assert Tarearbol.Full.synch(3) == {:ok, 5}
+
+    assert Tarearbol.Full.asynch() == :ok
+    Process.sleep(10)
+    assert Tarearbol.Full.asynch() == :ok
+    Process.sleep(10)
+    assert Tarearbol.Full.asynch() == :error
+    Process.sleep(700)
+
+    assert [ok: :ok] =
+             1..5 |> Task.async_stream(&Tarearbol.Full.asynch/1) |> Enum.to_list() |> Enum.uniq()
+
+    Process.sleep(700)
+    assert 20 == Enum.reduce(Tarearbol.Full.State.state().children, 0, &(&2 + elem(&1, 1).value))
+
+    GenServer.stop(pid)
+  end
+end

--- a/test/support/full.ex
+++ b/test/support/full.ex
@@ -1,0 +1,17 @@
+defmodule Tarearbol.Full do
+  @moduledoc false
+  use Tarearbol.Pool, continue: {Tarearbol.Full, :continue, 0}
+
+  def continue do
+    0
+  end
+
+  defsynch foo() do
+    {:replace, payload!() + 1}
+  end
+
+  defasynch bar() do
+    Process.sleep(10_000)
+    IO.puts(:bar_casted)
+  end
+end

--- a/test/support/full.ex
+++ b/test/support/full.ex
@@ -1,17 +1,23 @@
 defmodule Tarearbol.Full do
   @moduledoc false
-  use Tarearbol.Pool, continue: {Tarearbol.Full, :continue, 0}
+  use Tarearbol.Pool, init: &Tarearbol.Full.continue/0, pool_size: 2
 
-  def continue do
-    0
-  end
+  def continue, do: 0
 
-  defsynch foo() do
+  defsynch synch do
     {:replace, payload!() + 1}
   end
 
-  defasynch bar() do
-    Process.sleep(10_000)
-    IO.puts(:bar_casted)
+  defsynch synch(n) do
+    {:replace, payload!() + n}
+  end
+
+  defasynch asynch do
+    Process.sleep(500)
+    {:ok, id!()}
+  end
+
+  defasynch asynch(n) do
+    {:replace, payload!() + n}
   end
 end

--- a/test/tarearbol_test.exs
+++ b/test/tarearbol_test.exs
@@ -116,14 +116,14 @@ defmodule Tarearbol.Test do
   test "#run_at" do
     count = Enum.count(Tarearbol.Application.children())
 
-    run_at = DateTime.add(DateTime.utc_now(), 100, :millisecond)
+    run_at = DateTime.add(DateTime.utc_now(), 200, :millisecond)
 
-    Tarearbol.Errand.run_at(fn -> Process.sleep(100) end, run_at)
+    Tarearbol.Errand.run_at(fn -> Process.sleep(200) end, run_at)
     Process.sleep(50)
     assert Enum.count(Tarearbol.Application.children()) == count + 1
-    Process.sleep(100)
+    Process.sleep(200)
     assert Enum.count(Tarearbol.Application.children()) == count + 1
-    Process.sleep(100)
+    Process.sleep(200)
     assert Enum.count(Tarearbol.Application.children()) == count
   end
 


### PR DESCRIPTION
- **`Tarearbol.Pool`** to easily create worker pools on top of `Tarearbol.DynamicManager`
- **`cast/2`, `call/3`, `terminate/2`** callbacks for workers to initiale message passing from outside
- **`init:`** argument in call to `use Tarearbol.DynamicManager` to allow custom payload initialization (routed to `handle_continue/2` of underlying process